### PR TITLE
Con 545 audit aws inspector console url fixed

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -103,7 +103,7 @@ coreo_uni_util_jsrunner "inspector-tags-to-notifiers-array" do
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",
-                   :version => "1.9.7-beta30"
+                   :version => "1.9.7-beta33"
                },
                {
                    :name => "js-yaml",

--- a/table.yaml
+++ b/table.yaml
@@ -1,3 +1,3 @@
 inspector-findings:
-  "Inspector Finding": "__OBJECT__~https://console.aws.amazon.com/inspector/home?region=+__OBJECT__.violations.__RULE__.region+#/finding?filter=%7B%22findingArns%22:%22__OBJECT__"
+  "Inspector Finding": "__OBJECT__~https://console.aws.amazon.com/inspector/home?region=+__OBJECT__.violations.__RULE__.region+#/finding?filter=%7B%22findingArns%22:%22__OBJECT__%22%7D"
   "AWS Region": "+__OBJECT__.violations.__RULE__.region+"


### PR DESCRIPTION
 Generated Inventory Severity console urls works fine now.
![audit-aws-inspector-before](https://user-images.githubusercontent.com/8253376/27725323-90ffd82c-5d97-11e7-85fe-cfe2dc49f994.png)
![audit-aws-inspector-now](https://user-images.githubusercontent.com/8253376/27725345-afd9d7de-5d97-11e7-8837-e637f6b18f14.png)
